### PR TITLE
Chore: sort required TF vars to head of docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
+        args: ['--args=--sort-by-required']
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:


### PR DESCRIPTION
NOTE: this PR does not include the actual updated READMEs.

Chore: allow terraform-docs to sort required variables to top of Inputs section

Closes #45