### PR TITLE
closed #87

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -144,3 +144,5 @@ fileignoreconfig:
   checksum: 5ed655b3812b7993ac0a6d074abece9ab2fc99c58f843d11376e9c7c10422814
 - filename: modules/aws/terraform/gwlb-bigip-vpc/main.tf
   checksum: 90999ce57eba4fafee5b4b64fb2102613594b09b76b8fbbfa00451aef6bf5cff
+- filename: docs/solutions/delivery/application_delivery_controller/nginx/kic/labSetupAWS.rst
+  checksum: b9d3ce252c1bde9c444c2d1101e82e652fda2c2d1edbe8d33ca0c76bbd9e8fe8

--- a/docs/solutions/delivery/application_delivery_controller/nginx/kic/lab01.rst
+++ b/docs/solutions/delivery/application_delivery_controller/nginx/kic/lab01.rst
@@ -65,6 +65,8 @@ NGINX Ingress Controller provides a robust feature set to secure, strengthen, an
 
    .. note:: Building the image will take a few minutes (3-5)
 
+   .. note:: Terraform command ``terraform output`` displays environment outputs
+
    Within the Kubernetes-ingress repository are all the needed files to create our NGINX Ingress Controller Docker image. With the certificate and key in place, we can **make** our image. After the image is created, our local installation of docker will push our image to the ECR we created with Terraform. When Terraform applied our ECR object, it output the name of our registry. Its output was a prefix and looked like a URL.
 
    Example of Terraform outputs:

--- a/docs/solutions/delivery/application_delivery_controller/nginx/kic/labSetupAWS.rst
+++ b/docs/solutions/delivery/application_delivery_controller/nginx/kic/labSetupAWS.rst
@@ -147,8 +147,6 @@ This solution is leveraging Terraform to create and manage the following product
 
 7. Run the setup script - **This will create AWS resource objects**
 
-
-
    In the terminal window copy the below text and paste+enter:
 
    .. code-block::
@@ -171,15 +169,19 @@ This solution is leveraging Terraform to create and manage the following product
 
    .. warning:: Terraform is building several services, this can take 10-15 minutes
 
+   .. note:: If you need to see the outputs again later and have not saved them, utilize the ``terraform output`` command.
+
    The outputs from our Terraform run are in green. We will need this information to access our services and create/publish NGINX into the environment.
 
-   Save the outputs for the next few steps.
+   Save the outputs for the next several steps.
 
    Example:
 
    |image12|
 
 10. All of the Terraform-created objects are dynamic, so until running the Terraform template they did not exist. Now that the resources are created, we need to apply access to those services.
+
+   .. warning:: Terraform does not know about the changes in this step. If Terraform must be re-run, this step will need to be repeated.
 
     Step 1: Log in to ECR. Change the ``ecrRepositoryURL`` to the terraform output.
 
@@ -209,7 +211,7 @@ This solution is leveraging Terraform to create and manage the following product
 
     |image14|
 
-    Step 3: Update the Subnet Tags for the EKS cluster. Change the ``publicSubnetAZ1`` and ``publicSubnetAZ2`` to  the terraform output.
+    Step 3: Update the Subnet Tags for the EKS cluster. Change the ``kubernetesClusterName``, ``publicSubnetAZ1`` and ``publicSubnetAZ2`` to  the terraform output.
 
     In the terminal window copy the below text and paste+enter:
 
@@ -217,9 +219,9 @@ This solution is leveraging Terraform to create and manage the following product
 
        aws ec2 create-tags \
           --resources publicSubnetAZ1 publicSubnetAZ2 \
-          --tags Key=kubernetes.io/cluster/my-cluster-3820603181,Value=shared   Key=kubernetes.io/role/elb,Value=1
+          --tags Key=kubernetes.io/cluster/kubernetesClusterName,Value=shared   Key=kubernetes.io/role/elb,Value=1
 
-    For EKS to create an Elastic Load Balancer for our Ingress solution, two tags need to be placed on the public  subnets. Ideally, Terraform would add the tags. However, the EKS module from Terraform does not manipulate  those. So, we are doing it manually. These issues can be tracked here.
+    For EKS to create an Elastic Load Balancer for our Ingress solution, two tags need to be placed on the public subnets. Ideally, Terraform would add the tags. However, the EKS module from Terraform does not manipulate  those. So, we are doing it manually. These issues can be tracked here.
 
     - issue01_
     - issue02_


### PR DESCRIPTION
updates for more clarifying documentation
kubernetesClusterName in the subnet tags seems to have changed in aws,
kubernetesClusterName is required now to be specific to the EKS cluster
multiple notes about terraform output as a command