### PR TITLE
TLS: add module to store TLS certs in Secret Manager

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -206,3 +206,7 @@ fileignoreconfig:
   checksum: 7388b32e8ad7a467d9817011a270a57eadd10762f4df45df5d90d0d621962d24
 - filename: solutions/security/ingress-egress-inter-vpc-fw-gwlb/README.md
   checksum: d32462c3b49b2c49aa4bedb513ec601f978f990f9cbfbb594744dffc3f9e59cd
+- filename: modules/google/terraform/tls/main.tf
+  checksum: a411606cae2277545eff110520b9f2c87cbba7abd574da8d492406f9a3fcb899
+- filename: modules/google/terraform/tls/README.md
+  checksum: 50f99abd36a106305a613ba25d262f313596cb9afd6278cc89c5ad25ec54ae9f

--- a/.talismanrc
+++ b/.talismanrc
@@ -209,4 +209,4 @@ fileignoreconfig:
 - filename: modules/google/terraform/tls/main.tf
   checksum: a411606cae2277545eff110520b9f2c87cbba7abd574da8d492406f9a3fcb899
 - filename: modules/google/terraform/tls/README.md
-  checksum: 50f99abd36a106305a613ba25d262f313596cb9afd6278cc89c5ad25ec54ae9f
+  checksum: a01ca437c6d86d8d244320e58c7632d2c037fdb7faf246f2393b3d9c2a469d5c

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,3 +13,4 @@
 
 #modules owners
 /modules/aws/terraform/workstation @yossi-r
+/modules/google/terraform/tls @memes

--- a/modules/google/terraform/tls/README.md
+++ b/modules/google/terraform/tls/README.md
@@ -1,0 +1,101 @@
+# TLS
+
+<!-- spell-checker: ignore markdownlint -->
+This module will store the supplied TLS certificate and key, and optionally a CA
+certificate, in a Google Secret Manager slot. If a certificate and key are not
+provided, a self-signed certificate will be generated and stored in Secret Manager.
+
+## Generate a self-signed certificate with wildcard DNS for example.com
+
+<!-- spell-checker: disable -->
+```hcl
+module "tls" {
+    source                  = "../../../../../google/terraform/tls/"
+    gcpProjectId            = var.gcpProjectId
+    secret_manager_key_name = "my-tls-cert"
+    domain_name             = "example.com"
+}
+```
+<!-- spell-checker: enable -->
+
+## Generate a self-signed certificate and set secret accessors
+
+<!-- spell-checker: disable -->
+```hcl
+module "tls" {
+    source                  = "../../../../../google/terraform/tls/"
+    gcpProjectId            = var.gcpProjectId
+    secret_manager_key_name = "my-tls-cert"
+    domain_name             = "example.com"
+    secret_accessors        = [
+       "user:jane@example.com",
+       "group:admins@example.com",
+       "serviceAccount:webserver-sa@my-project.iam.gserviceaccount.com",
+    ]
+}
+```
+<!-- spell-checker: enable -->
+
+## Store an existing certificate and key pair
+
+<!-- spell-checker: disable -->
+```hcl
+module "tls" {
+    source                  = "../../../../../google/terraform/tls/"
+    gcpProjectId            = var.gcpProjectId
+    secret_manager_key_name = "my-tls-cert"
+    tls_cert                = file("/path/to/certificate.pem")
+    tls_key                 = file("/path/to/certificate.key")
+}
+```
+<!-- spell-checker: enable -->
+
+<!-- markdownlint-disable no-inline-html -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.14.5 |
+| google | >= 3.54 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| tls | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| tls_secret | memes/secret-manager/google | 1.0.2 |
+
+## Resources
+
+| Name |
+|------|
+| [tls_cert_request](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/cert_request) |
+| [tls_locally_signed_cert](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/locally_signed_cert) |
+| [tls_private_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) |
+| [tls_self_signed_cert](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert) |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| ca\_cert | An optional CA certificate to install in Secret Manager, if TLS cert and key pair<br>are provided. Ignored if a self-signed TLS cert is generated because either of<br>`tls_cert` or `tls_key` are missing. | `string` | `""` | no |
+| domain\_name | An optional DNS domain name to add to a generated TLS certificate with wildcard.<br>Ignored if `tls_cert` and `tls_key` are provided.<br><br>E.g. if domain\_name = "example.com", the generated TLS certificate will include<br>SANs for 'example.com' and '*.example.com', in addition to defaults. | `string` | `""` | no |
+| gcpProjectId | gcp project id | `string` | n/a | yes |
+| secret\_accessors | An optional list of users, groups, and/or service accounts that will be granted<br>access to the TLS secret value.<br><br>E.g. to allow service account foo@bar.iam.gserviceaccount.com to read the secret<br>secret\_accessors = [<br>  "serviceAccount:foo@bar.iam.gserviceaccount.com",<br>] | `list(string)` | `[]` | no |
+| secret\_manager\_key\_name | The unique key name to use for stored TLS credentials. Must be unique within the<br>GCP project specified by `gcpProjectId`. | `string` | n/a | yes |
+| tls\_cert | An optional TLS certificate, preferably a full chain, to install in Secret Manager.<br>If left blank (default), a self-signed cert will be generated and used. See also<br>`tls_key` and `ca_cert` variables. | `string` | `""` | no |
+| tls\_key | An optional TLS private key to install in Secret Manager. If left blank (default),<br>a self-signed cert will be generated and used. See also `tls_cert` and `ca_cert`<br>variables. | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| tls\_secret\_key | The project-local Secret Manager key containing the TLS certificate, key, and CA. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- markdownlint-enable no-inline-html -->

--- a/modules/google/terraform/tls/README.md
+++ b/modules/google/terraform/tls/README.md
@@ -56,7 +56,7 @@ module "tls" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.14.5 |
+| terraform | >= 0.14.5 |
 | google | >= 3.54 |
 
 ## Providers
@@ -69,7 +69,7 @@ module "tls" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| tls_secret | memes/secret-manager/google | 1.0.2 |
+| tls_secret | memes/secret-manager/google | 1.0.3 |
 
 ## Resources
 
@@ -84,11 +84,11 @@ module "tls" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| gcpProjectId | gcp project id | `string` | n/a | yes |
+| secret\_manager\_key\_name | The unique key name to use for stored TLS credentials. Must be unique within the<br>GCP project specified by `gcpProjectId`. | `string` | n/a | yes |
 | ca\_cert | An optional CA certificate to install in Secret Manager, if TLS cert and key pair<br>are provided. Ignored if a self-signed TLS cert is generated because either of<br>`tls_cert` or `tls_key` are missing. | `string` | `""` | no |
 | domain\_name | An optional DNS domain name to add to a generated TLS certificate with wildcard.<br>Ignored if `tls_cert` and `tls_key` are provided.<br><br>E.g. if domain\_name = "example.com", the generated TLS certificate will include<br>SANs for 'example.com' and '*.example.com', in addition to defaults. | `string` | `""` | no |
-| gcpProjectId | gcp project id | `string` | n/a | yes |
 | secret\_accessors | An optional list of users, groups, and/or service accounts that will be granted<br>access to the TLS secret value.<br><br>E.g. to allow service account foo@bar.iam.gserviceaccount.com to read the secret<br>secret\_accessors = [<br>  "serviceAccount:foo@bar.iam.gserviceaccount.com",<br>] | `list(string)` | `[]` | no |
-| secret\_manager\_key\_name | The unique key name to use for stored TLS credentials. Must be unique within the<br>GCP project specified by `gcpProjectId`. | `string` | n/a | yes |
 | tls\_cert | An optional TLS certificate, preferably a full chain, to install in Secret Manager.<br>If left blank (default), a self-signed cert will be generated and used. See also<br>`tls_key` and `ca_cert` variables. | `string` | `""` | no |
 | tls\_key | An optional TLS private key to install in Secret Manager. If left blank (default),<br>a self-signed cert will be generated and used. See also `tls_cert` and `ca_cert`<br>variables. | `string` | `""` | no |
 

--- a/modules/google/terraform/tls/main.tf
+++ b/modules/google/terraform/tls/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.14.5"
+  required_version = ">= 0.14.5"
   required_providers {
     google = {
       source  = "hashicorp/google"
@@ -33,7 +33,7 @@ locals {
 # Store the TLS certificate, key, and CA in Secret Manager.
 module "tls_secret" {
   source     = "memes/secret-manager/google"
-  version    = "1.0.2"
+  version    = "1.0.3"
   project_id = var.gcpProjectId
   id         = var.secret_manager_key_name
   secret     = jsonencode(local.tls_secret)

--- a/modules/google/terraform/tls/main.tf
+++ b/modules/google/terraform/tls/main.tf
@@ -1,0 +1,108 @@
+terraform {
+  required_version = "~> 0.14.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.54"
+    }
+  }
+}
+
+locals {
+  generate_tls = var.tls_cert == null || length(var.tls_cert) < 1 || var.tls_key == null || length(var.tls_key) < 1
+  tls_cert     = coalesce(join("", tls_locally_signed_cert.tls.*.cert_pem, tls_self_signed_cert.ca.*.cert_pem), var.tls_cert)
+  tls_key      = coalesce(join("", tls_private_key.tls.*.private_key_pem), var.tls_key)
+  ca_cert      = coalesce(join("", tls_self_signed_cert.ca.*.cert_pem), var.ca_cert)
+  tls_secret = merge(
+    {
+      cert = local.tls_cert,
+      key  = local.tls_key,
+    },
+    local.ca_cert != "" ? { ca = local.ca_cert } : {},
+  )
+  generated_dns_names = compact(concat(
+    var.domain_name != "" ? [format("*.%s", var.domain_name), var.domain_name] : [],
+    [
+      format("*.c.%s.internal", var.gcpProjectId),
+      "localhost",
+      "localhost.localdomain",
+    ]
+  ))
+}
+
+# Store the TLS certificate, key, and CA in Secret Manager.
+module "tls_secret" {
+  source     = "memes/secret-manager/google"
+  version    = "1.0.2"
+  project_id = var.gcpProjectId
+  id         = var.secret_manager_key_name
+  secret     = jsonencode(local.tls_secret)
+  accessors  = var.secret_accessors
+}
+
+# Generate a CA key, if needed
+resource "tls_private_key" "ca" {
+  count     = local.generate_tls ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = "2048"
+}
+
+# Generate a CA cert. if needed
+resource "tls_self_signed_cert" "ca" {
+  count           = local.generate_tls ? 1 : 0
+  key_algorithm   = tls_private_key.ca.0.algorithm
+  private_key_pem = tls_private_key.ca.0.private_key_pem
+  subject {
+    common_name         = format("CA (%s)", var.secret_manager_key_name)
+    organization        = "F5 Networks, Inc"
+    organizational_unit = "F5 DevCentral"
+    locality            = "Seattle"
+    province            = "Washington"
+    country             = "United States"
+  }
+  validity_period_hours = 720
+  early_renewal_hours   = 2
+  is_ca_certificate     = true
+  allowed_uses          = []
+}
+
+# Generate a TLS cert key, if needed
+resource "tls_private_key" "tls" {
+  count     = local.generate_tls ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = "2048"
+}
+
+# Generate a wildcard TLS csr for the domain, if needed
+resource "tls_cert_request" "tls" {
+  count           = local.generate_tls ? 1 : 0
+  key_algorithm   = tls_private_key.tls.0.algorithm
+  private_key_pem = tls_private_key.tls.0.private_key_pem
+  subject {
+    common_name         = format("TLS cert for %s", var.secret_manager_key_name)
+    organization        = "F5 Networks, Inc"
+    organizational_unit = "F5 DevCentral"
+    locality            = "Seattle"
+    province            = "Washington"
+    country             = "United States"
+  }
+  dns_names = local.generated_dns_names
+}
+
+# Generate the TLS cert for the domain
+resource "tls_locally_signed_cert" "tls" {
+  count                 = local.generate_tls ? 1 : 0
+  cert_request_pem      = tls_cert_request.tls.0.cert_request_pem
+  ca_key_algorithm      = tls_private_key.ca.0.algorithm
+  ca_private_key_pem    = tls_private_key.ca.0.private_key_pem
+  ca_cert_pem           = tls_self_signed_cert.ca.0.cert_pem
+  validity_period_hours = 720
+  early_renewal_hours   = 2
+  is_ca_certificate     = false
+  allowed_uses = [
+    "cert_signing",
+    "key_encipherment",
+    "client_auth",
+    "server_auth",
+  ]
+}

--- a/modules/google/terraform/tls/outputs.tf
+++ b/modules/google/terraform/tls/outputs.tf
@@ -1,0 +1,6 @@
+output "tls_secret_key" {
+  value       = module.tls_secret.secret_id
+  description = <<EOD
+The project-local Secret Manager key containing the TLS certificate, key, and CA.
+EOD
+}

--- a/modules/google/terraform/tls/variables.tf
+++ b/modules/google/terraform/tls/variables.tf
@@ -1,0 +1,70 @@
+# project
+
+variable "gcpProjectId" {
+  type        = string
+  description = "gcp project id"
+}
+
+variable "secret_manager_key_name" {
+  type        = string
+  description = <<EOD
+The unique key name to use for stored TLS credentials. Must be unique within the
+GCP project specified by `gcpProjectId`.
+EOD
+}
+
+variable "tls_cert" {
+  type        = string
+  default     = ""
+  description = <<EOD
+An optional TLS certificate, preferably a full chain, to install in Secret Manager.
+If left blank (default), a self-signed cert will be generated and used. See also
+`tls_key` and `ca_cert` variables.
+EOD
+}
+
+variable "tls_key" {
+  type        = string
+  default     = ""
+  description = <<EOD
+An optional TLS private key to install in Secret Manager. If left blank (default),
+a self-signed cert will be generated and used. See also `tls_cert` and `ca_cert`
+variables.
+EOD
+}
+
+variable "ca_cert" {
+  type        = string
+  default     = ""
+  description = <<EOD
+An optional CA certificate to install in Secret Manager, if TLS cert and key pair
+are provided. Ignored if a self-signed TLS cert is generated because either of
+`tls_cert` or `tls_key` are missing.
+EOD
+}
+
+variable "domain_name" {
+  type        = string
+  default     = ""
+  description = <<EOD
+An optional DNS domain name to add to a generated TLS certificate with wildcard.
+Ignored if `tls_cert` and `tls_key` are provided.
+
+E.g. if domain_name = "example.com", the generated TLS certificate will include
+SANs for 'example.com' and '*.example.com', in addition to defaults.
+EOD
+}
+
+variable "secret_accessors" {
+  type        = list(string)
+  default     = []
+  description = <<EOD
+An optional list of users, groups, and/or service accounts that will be granted
+access to the TLS secret value.
+
+E.g. to allow service account foo@bar.iam.gserviceaccount.com to read the secret
+secret_accessors = [
+  "serviceAccount:foo@bar.iam.gserviceaccount.com",
+]
+EOD
+}


### PR DESCRIPTION
 - can accept an existing TLS pair
 - will generate a self-signed pair if key and/or cert are unspecified

Closes #118 