### PR TITLE
Google workstation: fix for multiple invocations

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -69,7 +69,7 @@ fileignoreconfig:
 - filename: modules/aws/terraform/workstation/templates/startup.sh.tpl
   checksum: 296576d6c29232bf4b2168f2eaa1afe8c835035b23a51369c4b1202628f3043e
 - filename: modules/aws/terraform/workstation/main.tf
-  checksum: 0c46185b90ab9dd29e92ac48a9e3c9030bf88d0690b217d6703ab2a04e28a816
+  checksum: acf0b69eda490f7a01c7f73f32f304e9980116713288eb91f59d14d525b2c7a6
 - filename: solutions/workshop/google/.terraform.lock.hcl
   checksum: 173742541a76307c912f751e5deaa06571bf9bf92b64453f5c8ee75ca116440e
 - filename: solutions/workshop/google/admin.auto.tfvars.example

--- a/modules/google/terraform/workstation/outputs.tf
+++ b/modules/google/terraform/workstation/outputs.tf
@@ -1,5 +1,5 @@
 output "service_account" {
-  value       = module.sa.email
+  value       = local.service_account
   description = <<EOD
 The service account used by workstation instance.
 EOD

--- a/modules/google/terraform/workstation/variables.tf
+++ b/modules/google/terraform/workstation/variables.tf
@@ -168,3 +168,12 @@ Default value is 'false'. Setting value to true is required if the workstation
 is on a VPC network without a NAT gateway.
 EOD
 }
+
+variable "service_account" {
+  type        = string
+  default     = null
+  description = <<EOD
+The service account to use with workstation. If empty (default), a service
+account will be created.
+EOD
+}

--- a/test/integration/gcp-workstation/controls/workstation.rb
+++ b/test/integration/gcp-workstation/controls/workstation.rb
@@ -40,7 +40,7 @@ control 'workstation' do
     it { should_not be_empty }
     its(['project']) { should cmp project_id }
     its(['zone']) { should match(/^#{region}-[a-f]$/) }
-    its(['name']) { should cmp "#{prefix}-wkstn-#{build_suffix}" }
+    its(['name']) { should match(/^#{prefix}-wkstn-[0-9a-f]{4}-#{build_suffix}$/) }
   end
 
   describe google_compute_instance(project: params['project'], zone: params['zone'], name: params['name']) do


### PR DESCRIPTION
 - add a random id to VM name and firewall rule
 - allow user to supply a service account to use; fallback to generated SA.

Closes #139 